### PR TITLE
Remove old newsletter references

### DIFF
--- a/_notes/Easy to learn, hard to use.md
+++ b/_notes/Easy to learn, hard to use.md
@@ -42,4 +42,3 @@ I wish app developers and designers would think seriously about [creating a smo
 
 **The question we need to ask is: how might we make it rewarding to progress along the path to power user?**
 
-<iframe src="https://newsletter.robhaisfield.com/embed" width="480" height="320" style="border:1px solid #EEE; background:white;" frameborder="0" scrolling="no"></iframe>

--- a/_notes/continuous onboarding.md
+++ b/_notes/continuous onboarding.md
@@ -18,6 +18,3 @@ It should be noted that some apps have a more expansive range of potential use c
 
 "Explainer content" (documentation, app tours, videos, etc.) is valuable, but isn’t scalable. Most people ignore explainer content. Learnable design, on the other hand, means that, as the user attempts to do something, the app [communicates how it works through feedback loops](/notes/Feedback-loops-are-a-more-efficient-method-of-communication). Make the impact of the user's actions more clear and immediate, while signaling how it brings the user closer to or further from their goals. Pay attention to the user's choices, and based on those, connect users to the functionality that matches their intention.  
   
-_In many ways, this post is a rough outline for the whole book. If you click around the links, you’ll find long trails to follow. My task now is to figure out how to package it all to make sense and flow well in a linear order. As always, please comment any thoughts or questions!_
-
-<iframe src="https://newsletter.robhaisfield.com/embed" width="480" height="320" style="border:1px solid #EEE; background:white;" frameborder="0" scrolling="no"></iframe>

--- a/about.md
+++ b/about.md
@@ -6,7 +6,7 @@ permalink: /about
 redirect_from: /
 ---
 
-Welcome to my hypertext notebook. I've found hypertext as a medium to be incredibly liberating, and come with unique affordances. See [[Writing in hypertext]] for a primer on how to best consume this website. Currently, I'm building [WebSim](https://websim.ai), a platform for creating and sharing web apps, games, and other interactive experiences. You can follow my progress by subscribing to my [newsletter](newsletter.robhaisfield.com).
+Welcome to my hypertext notebook. I've found hypertext as a medium to be incredibly liberating, and come with unique affordances. See [[Writing in hypertext]] for a primer on how to best consume this website. Currently, I'm building [WebSim](https://websim.ai), a platform for creating and sharing web apps, games, and other interactive experiences.
 
 The majority of this website was written while I was working as a behavioral product strategy and gamification consultant, and has seen minimal updates since then. It discusses topics such as:
 
@@ -39,4 +39,3 @@ The majority of this website was written while I was working as a behavioral pro
 
 If you are interested in my research on Tools for Thought, see [Scaling Synthesis](https://scalingsynthesis.com).
 
-<iframe src="https://newsletter.robhaisfield.com/embed" width="480" height="320" style="border:1px solid #EEE; background:white;" frameborder="0" scrolling="no"></iframe>


### PR DESCRIPTION
## Summary
- strip newsletter references from the Start Here page
- drop embedded signup widgets from notes
- remove a note about plans for a book draft

## Testing
- `bundle exec jekyll build` *(fails: command not found)*